### PR TITLE
chore(local-dev): allow to run docker image locally with SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ dist/
 # misc
 .DS_Store
 *.pem
+*.key
+*.crt
 
 # debug
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -182,18 +182,18 @@ This script will:
 2. Run the container with SSL enabled:
 
 ```bash
-docker run --rm -d \
+docker run --rm \
     -e SSL=enabled \
-    -v $(pwd)/ssl:/ssl \
-    -e NEXTAUTH_URL='https://localhost:3443' \
-    -e NEXTAUTH_SECRET='your-secret-here' \
-    -e KEYCLOAK_HOST='http://localhost:8888' \
-    -e KEYCLOAK_REALM='default' \
-    -e KEYCLOAK_CLIENT_ID='sso-workflow-bridge-client' \
-    -e KEYCLOAK_CLIENT_SECRET=' ' \
+    -v ./local-dev/ssl:/ssl \
+    -e AUTH_URL='https://localhost:3443' \
+    -e AUTH_SECRET='your-secret-here' \
+    -e AUTH_KEYCLOAK_HOST='http://localhost:8888' \
+    -e AUTH_KEYCLOAK_REALM='default' \
+    -e AUTH_KEYCLOAK_CLIENT_ID='sso-workflow-bridge-client' \
+    -e AUTH_KEYCLOAK_CLIENT_SECRET=' ' \
     -e LHUT_API_URL='http://localhost:8089' \
     -p 3000:3000 -p 3443:3443 \
-    ghcr.io/littlehorse-enterprises/sso-workflow-bridge/sso-workflow-bridge-ui:main
+    ghcr.io/littlehorse-enterprises/lh-sso-workflow-bridge/lh-sso-workflow-bridge-ui:main
 ```
 
 When SSL is enabled, the UI will be available on:

--- a/local-dev/issue-certificates.sh
+++ b/local-dev/issue-certificates.sh
@@ -21,10 +21,10 @@ echo "Creating SSL Certificates"
 openssl req -x509 -sha256 -nodes \
     -days 3650 -newkey rsa:2048 \
     -subj '/O=LH User Tasks/CN=localhost' \
-    -keyout "$SSL_PATH/key.pem" \
-    -out "$SSL_PATH/cert.pem" \
+    -keyout "$SSL_PATH/tls.key" \
+    -out "$SSL_PATH/tls.crt" \
     -addext "subjectAltName = DNS:localhost" > /dev/null 2>&1
 
 echo "Certificates generated successfully in $SSL_PATH/"
-echo "- cert.pem: SSL certificate"
-echo "- key.pem: Private key"
+echo "- tls.crt: SSL certificate"
+echo "- tls.key: Private key"


### PR DESCRIPTION
This allows to test docker image locally with SSL enabled.